### PR TITLE
Adding a specific error for invalid totp code format

### DIFF
--- a/core/src/main/scala/io/tbrown/totp4s/Totp.scala
+++ b/core/src/main/scala/io/tbrown/totp4s/Totp.scala
@@ -31,7 +31,7 @@ object Totp {
   def checkCode[F[_]: Sync: Timer](code: Code, secret: Secret, timeStep: TimeStep, window: Window, hmac: Hmac): F[Boolean] =
     for {
       seconds <- Timer[F].clock.monotonic(TimeUnit.SECONDS)
-      digits  <- Sync[F].fromEither(RefType.applyRef[Digits](code.value.toString.length).leftMap(new RuntimeException(_)))
+      digits  <- Sync[F].fromEither(RefType.applyRef[Digits](code.value.toString.length).leftMap(InvalidCodeFormat))
       valid   <- List.range(0, window.value).existsM { i =>
         val timeSteps = TimeSteps((seconds - timeStep.value * i) / timeStep.value)
         genCodeInternal(secret, digits, timeSteps, hmac).map(_ === code)

--- a/core/src/main/scala/io/tbrown/totp4s/models.scala
+++ b/core/src/main/scala/io/tbrown/totp4s/models.scala
@@ -1,4 +1,5 @@
 package io.tbrown.totp4s
+import scala.util.control.NoStackTrace
 
 case class Code(value: String) extends AnyVal //6-8 digit TOTP password
 case class Secret(value: String) extends AnyVal //secret used to generate the TOTP
@@ -6,4 +7,4 @@ case class Window(value: Int) extends AnyVal //How many timesteps the TOTP will 
 case class TimeStep(value: Long) extends AnyVal //seconds range that the TOTP is valid for
 case class TimeSteps(value: Long) extends AnyVal // number of TimeSteps for the current UNIX time, this divided by TimeStep
 
-case class InvalidCodeFormat(msg: String) extends Throwable
+case class InvalidCodeFormat(msg: String) extends RuntimeException with NoStackTrace

--- a/core/src/main/scala/io/tbrown/totp4s/models.scala
+++ b/core/src/main/scala/io/tbrown/totp4s/models.scala
@@ -5,3 +5,5 @@ case class Secret(value: String) extends AnyVal //secret used to generate the TO
 case class Window(value: Int) extends AnyVal //How many timesteps the TOTP will be checked against for validation
 case class TimeStep(value: Long) extends AnyVal //seconds range that the TOTP is valid for
 case class TimeSteps(value: Long) extends AnyVal // number of TimeSteps for the current UNIX time, this divided by TimeStep
+
+case class InvalidCodeFormat(msg: String) extends Throwable

--- a/core/src/test/scala/io/tbrown/totp4s/TotpSpec.scala
+++ b/core/src/test/scala/io/tbrown/totp4s/TotpSpec.scala
@@ -70,6 +70,14 @@ class TotpSpec extends Specification with ScalaCheck {
         val genned = genCode[IO](secret, RefType.applyRefM[Digits](6), defaultTimeStep, HmacSha1)(Sync[IO], t).unsafeRunSync
         checkCode[IO](genned, secret, defaultTimeStep, window, HmacSha1)(Sync[IO], t2).unsafeRunSync must beFalse
       }
+
+      "fail when we have a code that is not of valid length" in {
+        val secret = Secret("something random")
+        implicit val t = testTimer(0)
+
+        checkCode[IO](Code("1"), secret, defaultTimeStep, window, HmacSha1).unsafeRunSync must throwA[InvalidCodeFormat]
+        checkCode[IO](Code("123456789"), secret, defaultTimeStep, window, HmacSha1).unsafeRunSync must throwA[InvalidCodeFormat]
+      }
     }
 
     "RFC Sha-1" should {
@@ -229,6 +237,7 @@ class TotpSpec extends Specification with ScalaCheck {
         genned must_== Code("47863826")
         checkCode[IO](genned, secret, defaultTimeStep, window, HmacSha512).unsafeRunSync must beTrue
       }
+
     }
   }
 }


### PR DESCRIPTION
I think it would be nice to have a specific error type when we fail to get a code that is an appropriate length. 

